### PR TITLE
Upgraded sbt-cxf plugins for sample project

### DIFF
--- a/examples/play-cxf-example/build.sbt
+++ b/examples/play-cxf-example/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies += "eu.sipria.play" %% "play-guice-cxf_play26" % "1.6.0"
 
-version in cxf := CxfVersion
+version in CXF := CxfVersion
 
 defaultArgs in wsdl2java := Seq(
   "-p", "services.sunset.rise"

--- a/examples/play-cxf-example/project/plugins.sbt
+++ b/examples/play-cxf-example/project/plugins.sbt
@@ -7,6 +7,6 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.2")
 
-addSbtPlugin("com.solinor.sbt" % "sbt-cxf" % "1.1")
+addSbtPlugin("io.paymenthighway.sbt" % "sbt-cxf" % "1.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
Hello!

I couldn't load sbt for the sample project, I was getting the error:
```
Loading project definition from /Users/valydia/Workspace/valydia/play-guice-cxf/play-cxf/project
java.lang.RuntimeException: Some keys were defined with the same name but different types: 'wsdls' (scala.collection.Seq[com.solinor.sbt.cxf.CxfPlugin$Import$Wsdl], scala.collection.Seq[io.paymenthighway.sbt.cxf.CxfPlugin$Import$Wsdl])
```