### PR TITLE
Update to work with Play 3.0

### DIFF
--- a/examples/play-cxf-example/build.sbt
+++ b/examples/play-cxf-example/build.sbt
@@ -21,11 +21,11 @@ libraryDependencies ++= Seq(
   "org.apache.cxf" % "cxf-rt-frontend-jaxws"    % CxfVersion,
   "org.apache.cxf" % "cxf-rt-transports-http"   % CxfVersion,
 
-  "eu.sipria.play" %% "play-guice-cxf_play28" % "1.8.0-RC1" /* changing() */,
+  "eu.sipria.play" %% "play-guice-cxf_play30" % "1.9.0" /* changing() */,
 
-  "org.scalatest"           %% "scalatest"          % "3.1.4"   % Test,
-  "org.scalatestplus"       %% "junit-4-13"         % "3.1.4.0" % Test,
-  "org.scalatestplus.play"  %% "scalatestplus-play" % "5.1.0"   % Test
+  "org.scalatest"           %% "scalatest"          % "3.2.19"   % Test,
+  "org.scalatestplus"       %% "junit-4-13"         % "3.2.19.0" % Test,
+  "org.scalatestplus.play"  %% "scalatestplus-play" % "7.0.0"   % Test
 )
 
 CXF / version := CxfVersion

--- a/examples/play-cxf-example/project/plugins.sbt
+++ b/examples/play-cxf-example/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
 addSbtPlugin("io.paymenthighway.sbt" % "sbt-cxf" % "1.7")
 

--- a/play-cxf/build.sbt
+++ b/play-cxf/build.sbt
@@ -45,7 +45,7 @@ val guiceCore = module("guice-cxf-core", file("guice-cxf-core"))
 
       "com.google.inject" % "guice"               % "4.2.3",
 
-      "com.typesafe.play" %% "play"               % PlayVersion % Optional,
+      "org.playframework" %% "play"               % PlayVersion % Optional,
     )
   )
 
@@ -66,16 +66,16 @@ val guicePlayEndpoint = module("guice-cxf-endpoint-play", file("guice-cxf-endpoi
   .settings(
 
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play"                     % PlayVersion % Provided,
-      "com.typesafe.play" %% "play-guice"               % PlayVersion % Provided,
-      "com.typesafe.play" %% "play-logback"             % PlayVersion % Test,
+      "org.playframework" %% "play"                     % PlayVersion % Provided,
+      "org.playframework" %% "play-guice"               % PlayVersion % Provided,
+      "org.playframework" %% "play-logback"             % PlayVersion % Test,
 
       "org.apache.cxf" % "cxf-core"                     % CxfVersion,
       "org.apache.cxf" % "cxf-rt-frontend-jaxws"        % CxfVersion  % Provided,
 
-      "com.typesafe.play" %% "play"                     % PlayVersion % Test,
-      "com.typesafe.play" %% "play-guice"               % PlayVersion % Test,
-      "com.typesafe.play" %% "play-akka-http-server"    % PlayVersion % Test,
+      "org.playframework" %% "play"                     % PlayVersion % Test,
+      "org.playframework" %% "play-guice"               % PlayVersion % Test,
+      "org.playframework" %% "play-pekko-http-server"    % PlayVersion % Test,
 
       "org.apache.cxf" % "cxf-rt-transports-http"       % CxfVersion  % Test,
 

--- a/play-cxf/build.sbt
+++ b/play-cxf/build.sbt
@@ -17,7 +17,7 @@ def module(id: String, base: java.io.File): Project = {
 
       organization := "eu.sipria.play",
 
-      version := "1.8.0",
+      version := "1.9.0",
 
       scalaVersion := "2.13.6",
       crossScalaVersions := Seq("2.12.14", "2.13.6"),

--- a/play-cxf/guice-cxf-endpoint-play/src/main/scala/org/apache/cxf/transport/play/CxfController.scala
+++ b/play-cxf/guice-cxf-endpoint-play/src/main/scala/org/apache/cxf/transport/play/CxfController.scala
@@ -4,9 +4,9 @@ import java.io.OutputStream
 
 import javax.inject.{Inject, Singleton}
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import org.apache.cxf.message.Message
 import play.api.http.HttpEntity
 import play.api.mvc._

--- a/play-cxf/guice-cxf-endpoint-play/src/main/scala/org/apache/cxf/transport/play/MessageExtractor.scala
+++ b/play-cxf/guice-cxf-endpoint-play/src/main/scala/org/apache/cxf/transport/play/MessageExtractor.scala
@@ -2,7 +2,7 @@ package org.apache.cxf.transport.play
 
 import java.io.InputStream
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.google.inject.ImplementedBy
 import org.apache.cxf.message.{Message, MessageImpl}
 import play.api.mvc.{RawBuffer, Request}

--- a/play-cxf/project/plugins.sbt
+++ b/play-cxf/project/plugins.sbt
@@ -12,11 +12,11 @@ def propOr(name: String, value: String): String = {
 }
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % propOr("play.version", "2.8.8"))
+addSbtPlugin("org.playframework" % "sbt-plugin" % propOr("play.version", "3.0.5"))
 
 addSbtPlugin("io.paymenthighway.sbt" % "sbt-cxf" % "1.7")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.1.0")
 


### PR DESCRIPTION
Fixes #6 

In Play 3.0 there were a few package changes: akka is switched out for apache pekko and the groupID of play is now org.playframework.

This PR will make this library compatible with 3.0 (it does break compatibility with lower play versions though).

I increased the Version number for technical reasons, but put that in an extra commit that can be left out if desired.